### PR TITLE
Support multiple geomery types in the same document.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,28 +45,26 @@ exports.fromGeoJson = async (geojson, fileName, options = {}) => {
 
   const symbols = {};
 
-  if (typeof options.symbol === "function") {
-    geojson.features.forEach(feature => {
-      const symbol = options.symbol(feature);
-      const id = md5(JSON.stringify(symbol));
+  geojson.features.forEach(feature => {
+    const symbol = {
+      geomType: feature.geometry.type,
+      symbol: typeof options.symbol === "function" ? options.symbol(feature) : options.symbol
+    };
+    const id = md5(JSON.stringify(symbol));
 
-      if (!symbols[id]) {
-        symbols[id] = symbol;
-      }
+    if (!symbols[id]) {
+      symbols[id] = symbol;
+    }
 
-      feature.properties[config.DEFAULT_STYLE_ID] = id;
-    });
-  } else if (typeof options.symbol === "object") {
-    symbols[config.DEFAULT_STYLE_ID] = options.symbol;
-  }
+    feature.properties[config.DEFAULT_STYLE_ID] = id;
+  });
 
   let kmlContent = tokml(geojson, {
     name: options.name || "name"
   });
 
   if (options.symbol) {
-    const geomType = getGeomType(geojson);
-    kmlContent = symbol.addTo(kmlContent, geomType, symbols);
+    kmlContent = symbol.addTo(kmlContent, symbols);
   }
 
   if (fileName) {
@@ -84,18 +82,6 @@ exports.fromGeoJson = async (geojson, fileName, options = {}) => {
     };
   }
 };
-
-function getGeomType(geojson) {
-  // Assume there is only one geometry type in the geojson
-  switch (geojson.features[0].geometry.type) {
-    case "Point":
-    case "Polygon":
-    case "LineString":
-      return geojson.features[0].geometry.type;
-    default:
-      throw new Error("Geometry type unsupported.");
-  }
-}
 
 function getGeometry(placemark) {
   var geomTag = placemark.find("./Point");

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -1,19 +1,19 @@
 const et = require("elementtree");
 const config = require("config");
 
-exports.addTo = function(kmlContent, geomType, symbols) {
+exports.addTo = function(kmlContent, symbols) {
   var kml = et.parse(kmlContent);
 
   for (const id in symbols) {
-    addSymbol(kml, geomType, symbols[id], id);
+    addSymbol(kml, symbols[id].geomType, symbols[id].symbol, id);
   }
 
-  addFeatureSymbol(kml, geomType, symbols);
+  addFeatureSymbol(kml);
 
   return kml.write();
 };
 
-function addFeatureSymbol(kml, geomType, symbols) {
+function addFeatureSymbol(kml) {
   kml.findall(".//Placemark").forEach(place => {
     const styleId = place.findtext(
       `./ExtendedData/Data[@name="${config.DEFAULT_STYLE_ID}"]/value`


### PR DESCRIPTION
If we try to convert a geojson document using different geometry types while trying to styles them differently, it fails as the current code only look for the first feature geometry type to generate all styles.

```javascript
kml.fromGeoJson(geoJson, 'dist/nuclear_power_plants.kml', {
  symbol: (feature) => {
    const settings = {
      'Polygon': {
        color: '#ff7700',
        alpha: 255,
        fill: true,
        outline: false,
      },
      'Point': {
        icon: 'http://maps.google.com/mapfiles/kml/pal3/icon39.png',
        scale: 1,
      }
    };
    return settings[feature.geometry.type];
  },
  name: 'name'
});
```

This pull request use each feature geometry type instead of just the first one.