### PR TITLE
Fix ExtendedData cleanup.

### DIFF
--- a/src/symbol.js
+++ b/src/symbol.js
@@ -19,7 +19,13 @@ function addFeatureSymbol(kml, featureStyleKey) {
     );
     const placeStyle = et.SubElement(place, "styleUrl");
     placeStyle.text = '#' + (styleId || featureStyleKey);
-    place.remove(`./ExtendedData/Data[@name="${featureStyleKey}"]`);
+
+    // Clean up ExtendedData styleId.
+    let extendedData = place.find('./ExtendedData');
+    extendedData.remove(extendedData.find(`./Data[@name="${featureStyleKey}"]`));
+    if (extendedData.findall('./*').length === 0) {
+      place.remove(extendedData);
+    }
   });
 }
 


### PR DESCRIPTION
I've seen that the `<ExtendedData>` sections of the generated `<Placemark>` contained some metadata used by gtran to associate styles with placemarks. Digging a bit I've seen that you included a piece of code in the `addFeatureSymbol` function to clean it up but it was not working. I found out that the elementtree library only cleans up children of the current element and only by passing the element to the `remove` function.

Here is the fix.